### PR TITLE
generate_models `--platform` option for rendering models that respect platform-supported features

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 >
 > Limitations:
 >
-> - models are generated without if-features flag set, this means all if-features are implicitly enabled. Note, that this will render models for features that your hardware might not have.
+> - By default, models are generated without if-features flag set, this means all if-features are implicitly enabled. Note, that this will render models for features that your hardware might not have. Use the --platform flag to render models that respect feature flags.
 > - if you found additional limitations, please open an issue or reach out in [Discord](https://discord.gg/tZvgjQ6PZf).
 
 ## Installation
@@ -108,6 +108,13 @@ To manually regenerate the Pydantic models for a given module, run the following
 ```bash
 # generate_models.py --module <model name>
 ./generate_models.py --module srl_nokia-acl
+```
+
+This can optionally be scoped to a specific platform from the yang map:
+
+```bash
+# generate_models.py --module <model name> --platform <platform name>
+./generate_models.py --module srl_nokia-acl --platform 7250-IXR-X1B
 ```
 
 The full list of the top level modules:

--- a/generate_models.py
+++ b/generate_models.py
@@ -22,6 +22,12 @@ def main() -> None:
         "--module", required=True, help="Module name to process", type=str
     )
     parser.add_argument(
+        "--platform",
+        required=False,
+        help="Platform name to determine enabled features (e.g. 7250-IXR-X1B). If unspecified, all features will be enabled",
+        type=str,
+    )
+    parser.add_argument(
         "--data-type",
         action="store",
         dest="data_type",
@@ -73,6 +79,16 @@ def main() -> None:
     relay_args.extend(
         ["-f", args.module.replace("srl_nokia-", "").replace("-", "_") + ".py"]
     )
+
+    if args.platform:
+        platform = collection.platforms.get(args.platform)
+        if not platform:
+            print(f"Platform '{args.platform}' not found in yang_map.yml")
+            return
+        features_string = ""
+        for feature in platform.features:
+            features_string += feature + ","
+        relay_args.extend(["-F", f"srl_nokia-features:{features_string}"])
 
     # For each augmented module, add its path as a deviation
     for augmented_module in yang_module.augmented_by:


### PR DESCRIPTION
Use the platform features already in the yang map to inform pyang of the supported features when evaluating yang feature flags.